### PR TITLE
Update dead link to radare2 book

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ s 0x08048470
 wx eb
 
 ## Debugging/Visual Mode
-https://radare.gitbooks.io/radare2book/content/introduction/basic_debugger_session.html
+https://book.rada.re/first_steps/basic_debugger_session.html
 
 
 ## Set breakpoint


### PR DESCRIPTION
Hi I found your repo useful and wanted to contribute an update for a dead book link to help others.

The referenced page was also moved inside of the book to chapter 2, check against archive of original link at https://web.archive.org/web/20150818235133/https://radare.gitbooks.io/radare2book/content/introduction/basic_debugger_session.html

Thanks!